### PR TITLE
Bump Erlang from 22.2 to 22.3

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-elixir@v1
       with:
         elixir-version: 1.10.0 # Define the elixir version [required]
-        otp-version: 22.2 # Define the OTP version [required]
+        otp-version: 22.3 # Define the OTP version [required]
     - name: Install Dependencies
       run: mix deps.get
     - name: Run Tests

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.10.0
-erlang 22.2
+erlang 22.3


### PR DESCRIPTION
We identified some issues on installing Erlang 22.2 in MacOS Catalina.