### PR TITLE
Change app name to hyphen format

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule GitPair.MixFile do
 
   def project do
     [
-      app: :git_pair,
+      app: :"git-pair",
       version: "0.1.0",
       elixir: "~> 1.10",
       escript: escript(),


### PR DESCRIPTION
In this format binary will be generated as `git-pair` instead `git_pair`.

Allowing to run commands, like this:

```
$ git pair status
```

Instead of:

```
$ git_pair status
```