### PR TITLE
Standardize git-pair application name

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule GitPair.MixFile do
 
   def project do
     [
-      app: :"git-pair",
+      app: :git_pair,
       description: "Automatically adds Co-authored-by mark to commits when you're pairing",
       version: "0.2.0",
       elixir: "~> 1.10",
@@ -35,7 +35,11 @@ defmodule GitPair.MixFile do
   end
 
   def escript do
-    [main_module: GitPair.CLI]
+    [
+      main_module: GitPair.CLI,
+      name: "git-pair",
+      path: "git-pair"
+    ]
   end
 
   defp package do


### PR DESCRIPTION
We were getting some warning messages complaining about application name when running tests:

```
You have configured application :"git-pair" in your configuration file,
but the application is not available.

This usually means one of:

  1. You have not added the application as a dependency in a mix.exs file.

  2. You are configuring an application that does not really exist.

Please ensure :"git-pair" exists or remove the configuration.
```

We've investigated further and discovered that we should use standardized name for application then customize [`escript` configs](https://hexdocs.pm/mix/master/Mix.Tasks.Escript.Build.html).