### PR TITLE
Use import Config as replacement of Mix.Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :git_pair,
   command_runner: GitPair.SystemMock


### PR DESCRIPTION
In Elixir v1.9.0 the Mix.Config was moved from Mix to Elixir's Config module.

> A new Config module has been added to Elixir. The previous
configuration API, Mix.Config, was part of the Mix build tool. But since
releases provide runtime configuration and Mix is not included in
releases, we ported the Mix.Config API to Elixir. In other words, use
Mix.Config has been soft-deprecated in favor of import Config.

See more at: https://elixirforum.com/t/elixir-v1-9-0-rc-0-released/22921
