### PR TITLE
Refactor status command to use Storage

### DIFF
--- a/lib/git_pair/actions.ex
+++ b/lib/git_pair/actions.ex
@@ -53,8 +53,20 @@ defmodule GitPair.Actions do
   end
 
   def status() do
-    ("Pairing with: \n\n" <> Enum.join(collaborators(), "\n"))
-    |> output()
+    case storage().fetch_all() do
+      {:ok, collaborators} when length(collaborators) > 0 ->
+        collaborators =
+          collaborators
+          |> Enum.map(fn collaborator ->
+            "#{collaborator[:identifier]} <#{collaborator[:email]}>"
+          end)
+          |> Enum.join("\n")
+
+        output("Pairing with:\n\n" <> collaborators)
+
+      _ ->
+        output("You aren't pairing with anyone")
+    end
   end
 
   def stop() do

--- a/lib/git_pair/actions.ex
+++ b/lib/git_pair/actions.ex
@@ -54,7 +54,7 @@ defmodule GitPair.Actions do
 
   def status() do
     case storage().fetch_all() do
-      {:ok, collaborators} when length(collaborators) > 0 ->
+      {:ok, collaborators} when collaborators != [] ->
         collaborators =
           collaborators
           |> Enum.map(fn collaborator ->

--- a/lib/git_pair/actions.ex
+++ b/lib/git_pair/actions.ex
@@ -70,9 +70,19 @@ defmodule GitPair.Actions do
   end
 
   def stop() do
-    result = command("--unset-all")
+    case storage().remove_all() do
+      {:ok, []} ->
+        output("You aren't pairing with anyone")
 
-    output(result, "Stopped pairing with everyone")
+      {:ok, coauthors} ->
+        coauthors_message = "You were pairing previously with:\n" <>
+          Enum.join(coauthors, "\n")
+
+        output("Pairing session stopped!\n\n" <> coauthors_message)
+
+      _ ->
+        output("Failed to stop pairing session")
+    end
   end
 
   def version() do

--- a/lib/git_pair/actions.ex
+++ b/lib/git_pair/actions.ex
@@ -141,14 +141,6 @@ defmodule GitPair.Actions do
     command_runner().cmd("git", [@git_config, action, @key])
   end
 
-  defp command(action, [username]) do
-    command_runner().cmd("git", [@git_config, action, @key, username])
-  end
-
-  defp command(_action, _usernames) do
-    {:error, "Unsuported multiple users"}
-  end
-
   def storage() do
     Application.get_env(:git_pair, :storage, Storage)
   end

--- a/lib/git_pair/behaviours/storage_behaviour.ex
+++ b/lib/git_pair/behaviours/storage_behaviour.ex
@@ -5,4 +5,6 @@ defmodule GitPair.StorageBehaviour do
   @callback add(list(String.t())) :: {atom(), list()}
 
   @callback remove(String.t()) :: {atom(), list()}
+
+  @callback fetch(String.t()) :: {list()}
 end

--- a/lib/git_pair/behaviours/storage_behaviour.ex
+++ b/lib/git_pair/behaviours/storage_behaviour.ex
@@ -7,4 +7,5 @@ defmodule GitPair.StorageBehaviour do
   @callback remove(String.t()) :: {atom(), list()}
 
   @callback fetch(String.t()) :: {list()}
+  @callback fetch_all() :: {list()}
 end

--- a/lib/git_pair/behaviours/storage_behaviour.ex
+++ b/lib/git_pair/behaviours/storage_behaviour.ex
@@ -6,6 +6,6 @@ defmodule GitPair.StorageBehaviour do
 
   @callback remove(String.t()) :: {atom(), list()}
 
-  @callback fetch(String.t()) :: {list()}
-  @callback fetch_all() :: {list()}
+  @callback fetch(String.t()) :: {atom(), list()}
+  @callback fetch_all() :: {atom(), list()}
 end

--- a/lib/git_pair/behaviours/storage_behaviour.ex
+++ b/lib/git_pair/behaviours/storage_behaviour.ex
@@ -5,6 +5,7 @@ defmodule GitPair.StorageBehaviour do
   @callback add(list(String.t())) :: {atom(), list()}
 
   @callback remove(String.t()) :: {atom(), list()}
+  @callback remove_all() :: {atom(), list()}
 
   @callback fetch(String.t()) :: {atom(), list()}
   @callback fetch_all() :: {atom(), list()}

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -27,6 +27,21 @@ defmodule GitPair.Storage do
     )
   end
 
+  def remove_all() do
+    case fetch_all() do
+      {:ok, coauthors} when coauthors != [] ->
+        coauthor_identifiers = Enum.map(coauthors, fn coauthor ->
+          {:ok, coauthor} = remove(coauthor[:identifier])
+
+          coauthor[:identifier]
+        end)
+
+        {:ok, coauthor_identifiers}
+      _ ->
+        {:ok, []}
+    end
+  end
+
   def fetch(identifier) do
     {result, @success_exit_status} = run(["--get", "#{@key}.#{identifier}.email"])
 

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -27,6 +27,18 @@ defmodule GitPair.Storage do
     )
   end
 
+  def fetch(identifier) do
+    {result, @success_exit_status} = run(["--get", "#{@key}.#{identifier}.email"])
+
+    [email, _tail] = String.split(result, "\n")
+
+    {:ok,
+     [
+       identifier: identifier,
+       email: email
+     ]}
+  end
+
   defp build_result(@success_exit_status, data) do
     {:ok, data}
   end

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -39,6 +39,29 @@ defmodule GitPair.Storage do
      ]}
   end
 
+  def fetch_all do
+    case run(["--get-regexp", "#{@key}.*.identifier"]) do
+      {collaborators, @success_exit_status} ->
+        collaborators =
+          String.split(collaborators, "\n")
+          |> (fn collaborators ->
+                List.delete_at(collaborators, length(collaborators) - 1)
+              end).()
+          |> Enum.map(fn collaborator ->
+            [_key, collaborator] = String.split(collaborator, " ")
+
+            {:ok, collaborator_data} = fetch(collaborator)
+
+            collaborator_data
+          end)
+
+        {:ok, collaborators}
+
+      _ ->
+        {:ok, []}
+    end
+  end
+
   defp build_result(@success_exit_status, data) do
     {:ok, data}
   end

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -1,7 +1,7 @@
 defmodule GitPair.Storage do
   @git_config "config"
   @key "pair"
-  @github_noreply_email "@users.noreply.github.com"
+  @github_noreply_email_domain "users.noreply.github.com"
   @success_exit_status 0
 
   def add([identifier, email]) do
@@ -15,8 +15,8 @@ defmodule GitPair.Storage do
      ]}
   end
 
-  def add(identifier) do
-    add([identifier, identifier <> @github_noreply_email])
+  def add([identifier]) do
+    add([identifier, "#{identifier}@#{@github_noreply_email_domain}"])
   end
 
   def remove(identifier) do

--- a/test/actions_test.exs
+++ b/test/actions_test.exs
@@ -53,15 +53,39 @@ defmodule GitPair.ActionsTest do
     assert message == "User fake-user removed"
   end
 
-  test ".status calls git config get-all command" do
-    expect(SystemMock, :cmd, fn _cmd, _options ->
-      {"fake-user\n", 0}
+  test ".status prints a list of collaborators when pairing" do
+    expect(StorageMock, :fetch_all, fn ->
+      {:ok,
+       [
+         [
+           identifier: "fake_user",
+           email: "fake_user@example.com"
+         ],
+         [
+           identifier: "fake_user_2",
+           email: "fake_user_2@example.com"
+         ]
+       ]}
     end)
 
     {result, message} = Actions.status()
 
     assert result == :ok
-    assert message == "Pairing with: \n\nfake-user"
+
+    assert message ==
+             "Pairing with:\n\nfake_user <fake_user@example.com>\nfake_user_2 <fake_user_2@example.com>"
+  end
+
+  test ".status prints a message when not pairing" do
+    expect(StorageMock, :fetch_all, fn ->
+      {:ok, []}
+    end)
+
+    {result, message} = Actions.status()
+
+    assert result == :ok
+
+    assert message == "You aren't pairing with anyone"
   end
 
   test ".stop calls git config --unset-all command" do

--- a/test/actions_test.exs
+++ b/test/actions_test.exs
@@ -5,7 +5,6 @@ defmodule GitPair.ActionsTest do
 
   alias GitPair.Actions
   alias GitPair.StorageMock
-  alias GitPair.SystemMock
 
   setup :verify_on_exit!
 
@@ -88,15 +87,15 @@ defmodule GitPair.ActionsTest do
     assert message == "You aren't pairing with anyone"
   end
 
-  test ".stop calls git config --unset-all command" do
-    expect(SystemMock, :cmd, fn _cmd, _options ->
-      {"", 0}
+  test ".stop stops pairing session by removing coauthors from storage" do
+    expect(StorageMock, :remove_all, fn ->
+      {:ok, ["fake_user", "fake_user_2"]}
     end)
 
     {result, message} = Actions.stop()
 
     assert result == :ok
-    assert message == "Stopped pairing with everyone"
+    assert message == "Pairing session stopped!\n\nYou were pairing previously with:\nfake_user\nfake_user_2"
   end
 
   test ".version displays current app version" do

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -93,4 +93,22 @@ defmodule GitPair.StorageTest do
              identifier: "fake_user"
            ]
   end
+
+  test "fetch/1 returns pair information with identifier and email" do
+    command_prefix = ["config", "--get"]
+
+    expect(SystemMock, :cmd, fn _cmd, options ->
+      assert options == command_prefix ++ ["pair.fake_user.email"]
+      {"fake_user@example.com\n", 0}
+    end)
+
+    {result, user_data} = Storage.fetch("fake_user")
+
+    assert result == :ok
+
+    assert user_data == [
+             identifier: "fake_user",
+             email: "fake_user@example.com"
+           ]
+  end
 end

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -24,7 +24,7 @@ defmodule GitPair.StorageTest do
         {"", 0}
       end)
 
-      {result, user_data} = Storage.add("fake_user")
+      {result, user_data} = Storage.add(["fake_user"])
 
       assert result == :ok
 

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -111,4 +111,43 @@ defmodule GitPair.StorageTest do
              email: "fake_user@example.com"
            ]
   end
+
+  test "fetch_all/0 returns a list of collaborators" do
+    fetch_all_command_prefix = ["config", "--get-regexp", "pair.*.identifier"]
+
+    expect(SystemMock, :cmd, fn _cmd, options ->
+      assert options == fetch_all_command_prefix
+
+      {"pair.fake_user.identifier fake_user\npair.fake_user_2.identifier fake_user_2\n", 0}
+    end)
+
+    fetch_command_prefix = ["config", "--get"]
+
+    expect(SystemMock, :cmd, fn _cmd, options ->
+      assert options == fetch_command_prefix ++ ["pair.fake_user.email"]
+
+      {"fake_user@example.com\n", 0}
+    end)
+
+    expect(SystemMock, :cmd, fn _cmd, options ->
+      assert options == fetch_command_prefix ++ ["pair.fake_user_2.email"]
+
+      {"fake_user_2@example.com\n", 0}
+    end)
+
+    {result, collaborators} = Storage.fetch_all()
+
+    assert result == :ok
+
+    assert collaborators == [
+             [
+               identifier: "fake_user",
+               email: "fake_user@example.com"
+             ],
+             [
+               identifier: "fake_user_2",
+               email: "fake_user_2@example.com"
+             ]
+           ]
+  end
 end


### PR DESCRIPTION
## Motivation

In order to fetch pairs from `Storage` module and print its email, we need to refactor `Actions` to use `Storage`.

## Proposed Solution

Introduce `Storage.fetch/1` and `Storage.fetch_all/0` to retrieve collaborators data then refactor `Actions` to use them.