### PR TITLE
Use Storage module to stop pairing session

### DIFF
--- a/lib/git_pair/actions.ex
+++ b/lib/git_pair/actions.ex
@@ -70,9 +70,19 @@ defmodule GitPair.Actions do
   end
 
   def stop() do
-    result = command("--unset-all")
+    case storage().remove_all() do
+      {:ok, []} ->
+        output("You aren't pairing with anyone")
 
-    output(result, "Stopped pairing with everyone")
+      {:ok, coauthors} ->
+        coauthors_message = "You were pairing previously with:\n" <>
+          Enum.join(coauthors, "\n")
+
+        output("Pairing session stopped!\n\n" <> coauthors_message)
+
+      _ ->
+        output("Failed to stop pairing session")
+    end
   end
 
   def version() do

--- a/lib/git_pair/actions.ex
+++ b/lib/git_pair/actions.ex
@@ -141,14 +141,6 @@ defmodule GitPair.Actions do
     command_runner().cmd("git", [@git_config, action, @key])
   end
 
-  defp command(action, [username]) do
-    command_runner().cmd("git", [@git_config, action, @key, username])
-  end
-
-  defp command(_action, _usernames) do
-    {:error, "Unsuported multiple users"}
-  end
-
   def storage() do
     Application.get_env(:git_pair, :storage, Storage)
   end

--- a/lib/git_pair/behaviours/storage_behaviour.ex
+++ b/lib/git_pair/behaviours/storage_behaviour.ex
@@ -5,6 +5,7 @@ defmodule GitPair.StorageBehaviour do
   @callback add(list(String.t())) :: {atom(), list()}
 
   @callback remove(String.t()) :: {atom(), list()}
+  @callback remove_all() :: {atom(), list()}
 
   @callback fetch(String.t()) :: {atom(), list()}
   @callback fetch_all() :: {atom(), list()}

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -27,6 +27,21 @@ defmodule GitPair.Storage do
     )
   end
 
+  def remove_all() do
+    case fetch_all() do
+      {:ok, coauthors} when coauthors != [] ->
+        coauthor_identifiers = Enum.map(coauthors, fn coauthor ->
+          {:ok, coauthor} = remove(coauthor[:identifier])
+
+          coauthor[:identifier]
+        end)
+
+        {:ok, coauthor_identifiers}
+      _ ->
+        {:ok, []}
+    end
+  end
+
   def fetch(identifier) do
     {result, @success_exit_status} = run(["--get", "#{@key}.#{identifier}.email"])
 

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -1,7 +1,7 @@
 defmodule GitPair.Storage do
   @git_config "config"
   @key "pair"
-  @github_noreply_email "@users.noreply.github.com"
+  @github_noreply_email_domain "users.noreply.github.com"
   @success_exit_status 0
 
   def add([identifier, email]) do
@@ -15,8 +15,8 @@ defmodule GitPair.Storage do
      ]}
   end
 
-  def add(identifier) do
-    add([identifier, identifier <> @github_noreply_email])
+  def add([identifier]) do
+    add([identifier, "#{identifier}@#{@github_noreply_email_domain}"])
   end
 
   def remove(identifier) do

--- a/test/actions_test.exs
+++ b/test/actions_test.exs
@@ -5,7 +5,6 @@ defmodule GitPair.ActionsTest do
 
   alias GitPair.Actions
   alias GitPair.StorageMock
-  alias GitPair.SystemMock
 
   setup :verify_on_exit!
 
@@ -88,15 +87,15 @@ defmodule GitPair.ActionsTest do
     assert message == "You aren't pairing with anyone"
   end
 
-  test ".stop calls git config --unset-all command" do
-    expect(SystemMock, :cmd, fn _cmd, _options ->
-      {"", 0}
+  test ".stop stops pairing session by removing coauthors from storage" do
+    expect(StorageMock, :remove_all, fn ->
+      {:ok, ["fake_user", "fake_user_2"]}
     end)
 
     {result, message} = Actions.stop()
 
     assert result == :ok
-    assert message == "Stopped pairing with everyone"
+    assert message == "Pairing session stopped!\n\nYou were pairing previously with:\nfake_user\nfake_user_2"
   end
 
   test ".version displays current app version" do

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -24,7 +24,7 @@ defmodule GitPair.StorageTest do
         {"", 0}
       end)
 
-      {result, user_data} = Storage.add("fake_user")
+      {result, user_data} = Storage.add(["fake_user"])
 
       assert result == :ok
 


### PR DESCRIPTION
## Motivation

In order to remove both entries `identifier` and `email` we need to fetch existing identifiers to remove the entire section using `Storage` module.

## Proposed solution

- [x] Remove useless `Actions.command/2`
- [x] Introduce `Storage.remove_all/0` to iterate over `identifiers` and remove entire section
- [x] Refactor `Actions.stop/0` to use `Storage.remove_all/0` (now it prints coauthor identifiers if you were pairing and tells with you aren't pairing with anyone)
