### PR TITLE
Fix add with identifier-only command

### DIFF
--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -1,7 +1,7 @@
 defmodule GitPair.Storage do
   @git_config "config"
   @key "pair"
-  @github_noreply_email "@users.noreply.github.com"
+  @github_noreply_email_domain "users.noreply.github.com"
   @success_exit_status 0
 
   def add([identifier, email]) do
@@ -15,8 +15,8 @@ defmodule GitPair.Storage do
      ]}
   end
 
-  def add(identifier) do
-    add([identifier, identifier <> @github_noreply_email])
+  def add([identifier]) do
+    add([identifier, "#{identifier}@#{@github_noreply_email_domain}"])
   end
 
   def remove(identifier) do

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -24,7 +24,7 @@ defmodule GitPair.StorageTest do
         {"", 0}
       end)
 
-      {result, user_data} = Storage.add("fake_user")
+      {result, user_data} = Storage.add(["fake_user"])
 
       assert result == :ok
 


### PR DESCRIPTION
## Motivation

When trying to add pair using `identifier` only, we was getting the following error:

```
$ git pair add fake_user
** (ArgumentError) argument error
    (git_pair 0.3.0) lib/storage.ex:19: GitPair.Storage.add/1
    (git_pair 0.3.0) lib/git_pair/actions.ex:44: GitPair.Actions.add/1
    (git_pair 0.3.0) lib/git_pair/cli.ex:33: GitPair.CLI.main/1
    (elixir 1.10.0) lib/kernel/cli.ex:124: anonymous fn/3 in Kernel.CLI.exec_fun/2
```

## Proposed solution

Fix `Storage.add/1` to accept a list with a single entry instead the whole list.

Also made some enhancements in `@github_noreply_email` module attribute (renaming it to `@github_noreply_email_domain` to be more semantic).
